### PR TITLE
Rules don't have to be globally installed

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,9 +8,8 @@ This [CoffeeLint](http://www.coffeelint.org) plugin checks to make sure there ar
 ## Installation
 
 ```sh
-[sudo] npm install -g coffeelint-limit-newlines
+npm install coffeelint-limit-newlines
 ```
-> ***Note:*** *Right now a Coffeelint plugin cannot be installed as a project dependency and must be installed globally. Perhaps this will be improved in a future version of Coffeelint. If you would like to track progress on this enhancement head [over here](https://github.com/clutchski/coffeelint/issues/210).*
 
 ## Usage
 


### PR DESCRIPTION
I don't remember exactly which version this changed, but issue referenced in your original readme has been closed.
